### PR TITLE
Remove empty agents reference from productpowers plugin

### DIFF
--- a/plugins/productpowers/.claude-plugin/plugin.json
+++ b/plugins/productpowers/.claude-plugin/plugin.json
@@ -5,6 +5,5 @@
   "author": {
     "name": "Trevin Chow"
   },
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Remove unused agents directory reference from productpowers plugin manifest
- The empty agents directory was causing plugin installation to fail with validation errors

## Test plan
- [ ] Run `/plugin install productpowers@tmc-marketplace` and verify it installs successfully