### PR TITLE
Add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "plugin-dev@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.claude/settings.local.json
+.worktrees/
+.DS_Store
+*.log
+node_modules/
+.codex/


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with the plugin-dev plugin enabled for the project
- Adds `.gitignore` to exclude user-specific local settings (`.claude/settings.local.json`)

## Test plan
- [x] Verify settings.json is tracked
- [x] Verify settings.local.json is ignored