### PR TITLE
Add Claude Code automations for plugin marketplace

### DIFF
--- a/.claude/agents/plugin-reviewer/AGENT.md
+++ b/.claude/agents/plugin-reviewer/AGENT.md
@@ -1,0 +1,86 @@
+---
+name: plugin-reviewer
+description: Review plugin submissions for marketplace compliance. Use when adding or updating plugins to check for common issues.
+---
+
+# Plugin Reviewer
+
+You are a specialized reviewer for Claude Code plugins submitted to the tmc-marketplace.
+
+## Review Checklist
+
+### 1. Plugin Manifest (plugin.json)
+
+- [ ] Valid JSON syntax
+- [ ] Has `name` matching directory name
+- [ ] Has `version` in semver format
+- [ ] Has non-empty `description`
+- [ ] Has `author.name`
+- [ ] `skills` path points to existing directory (if skills exist)
+- [ ] `agents` path points to existing directory (if agents exist)
+
+### 2. Skills (SKILL.md files)
+
+For each skill:
+- [ ] Has valid YAML frontmatter between `---` markers
+- [ ] Frontmatter includes `name`
+- [ ] Frontmatter includes `description` explaining when to use
+- [ ] Description is clear about invocation context
+- [ ] If `disable-model-invocation: true`, skill has side effects (deploy, commit, send)
+- [ ] If `user-invocable: false`, skill is for background knowledge only
+- [ ] Content provides actionable guidance
+
+### 3. Agents (AGENT.md files)
+
+For each agent:
+- [ ] Has valid YAML frontmatter
+- [ ] Frontmatter includes `name`
+- [ ] Frontmatter includes `description`
+- [ ] Agent has clear purpose and specialization
+
+### 4. Documentation
+
+- [ ] README.md exists
+- [ ] README describes what the plugin does
+- [ ] README includes installation instructions
+- [ ] README lists available skills and agents
+
+### 5. Marketplace Integration
+
+- [ ] Plugin registered in `.claude-plugin/marketplace.json`
+- [ ] Registry entry has matching name, version, description
+- [ ] Source path is correct
+
+### 6. No Deprecated Patterns
+
+- [ ] No `commands/` directory (use skills instead)
+- [ ] No references to old command syntax
+
+## Review Output
+
+Provide a structured review:
+
+```markdown
+## Plugin Review: <plugin-name>
+
+### Summary
+[PASS/FAIL] - Brief overall assessment
+
+### Findings
+
+#### Critical Issues (must fix)
+- Issue description and location
+
+#### Warnings (should fix)
+- Warning description and suggestion
+
+#### Suggestions (nice to have)
+- Improvement ideas
+
+### Checklist Results
+- Manifest: [X/Y passed]
+- Skills: [X/Y passed]
+- Agents: [X/Y passed]
+- Docs: [X/Y passed]
+- Registry: [X/Y passed]
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "enabledPlugins": {
-    "plugin-dev@claude-plugins-official": true
+    "plugin-dev@claude-plugins-official": true,
+    "superpowers-developing-for-claude-code@superpowers-marketplace": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'marketplace.json'; then echo '⚠️  Editing marketplace registry - ensure plugin entry has: name, source, description, version'; fi"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/new-plugin/SKILL.md
+++ b/.claude/skills/new-plugin/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: new-plugin
+description: Scaffold a new plugin with proper marketplace structure
+disable-model-invocation: true
+user-invocable: true
+---
+
+# New Plugin Scaffolder
+
+Create a new plugin for the tmc-marketplace with the correct structure.
+
+## Usage
+
+```
+/new-plugin <plugin-name>
+```
+
+## What This Creates
+
+```
+plugins/<plugin-name>/
+  .claude-plugin/plugin.json   # Plugin manifest
+  skills/                      # Skills directory
+  agents/                      # Agents directory (if needed)
+  README.md                    # Plugin documentation
+```
+
+## Workflow
+
+1. **Get plugin name** from args or ask user
+2. **Validate name**: lowercase, hyphenated, no spaces
+3. **Check for conflicts**: Ensure plugin doesn't already exist
+4. **Create structure**:
+
+### plugin.json template
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "<description>",
+  "author": {
+    "name": "Trevin Chow"
+  },
+  "skills": "./skills/"
+}
+```
+
+### README.md template
+
+```markdown
+# <plugin-name>
+
+<description>
+
+## Installation
+
+\`\`\`
+/plugin marketplace add tmchow/tmc-marketplace
+/plugin install <plugin-name>@tmc-marketplace
+\`\`\`
+
+## Skills
+
+- List skills here
+
+## Agents
+
+- List agents here (if any)
+```
+
+5. **Register in marketplace**: Add entry to `.claude-plugin/marketplace.json`
+6. **Confirm**: Show created structure and next steps
+
+## Next Steps After Creation
+
+Tell the user:
+- Add skills to `plugins/<plugin-name>/skills/<skill-name>/SKILL.md`
+- Add agents to `plugins/<plugin-name>/agents/<agent-name>/AGENT.md` (optional)
+- Update README.md with skill/agent documentation
+- Run `/validate-plugin <plugin-name>` before committing

--- a/.claude/skills/validate-plugin/SKILL.md
+++ b/.claude/skills/validate-plugin/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: validate-plugin
+description: Validate plugin structure and manifests against marketplace requirements
+user-invocable: true
+---
+
+# Plugin Validator
+
+Validate a plugin meets marketplace requirements before publishing.
+
+## Usage
+
+```
+/validate-plugin <plugin-name>
+```
+
+Or validate all plugins:
+
+```
+/validate-plugin --all
+```
+
+## Validation Checks
+
+### 1. Plugin Structure
+
+```bash
+# Check required files exist
+ls plugins/<plugin-name>/.claude-plugin/plugin.json
+ls plugins/<plugin-name>/README.md
+ls plugins/<plugin-name>/skills/  # At least skills/ or agents/ must exist
+```
+
+### 2. plugin.json Validation
+
+Required fields:
+- `name` - must match directory name
+- `version` - semver format (e.g., "0.1.0")
+- `description` - non-empty string
+- `author.name` - non-empty string
+- `skills` - path to skills directory (if skills exist)
+- `agents` - path to agents directory (if agents exist)
+
+```bash
+# Validate JSON syntax
+cat plugins/<plugin-name>/.claude-plugin/plugin.json | jq .
+```
+
+### 3. Skill Validation
+
+For each `plugins/<plugin-name>/skills/*/SKILL.md`:
+
+**Required frontmatter:**
+```yaml
+---
+name: skill-name        # Required
+description: ...        # Required - when Claude should use this
+---
+```
+
+**Optional frontmatter:**
+```yaml
+disable-model-invocation: true   # User-only skill
+user-invocable: false            # Claude-only skill
+```
+
+**Check:** Frontmatter must be valid YAML between `---` markers
+
+### 4. Agent Validation
+
+For each `plugins/<plugin-name>/agents/*/AGENT.md`:
+
+**Required frontmatter:**
+```yaml
+---
+name: agent-name        # Required
+description: ...        # Required - when Claude should use this agent
+---
+```
+
+### 5. Marketplace Registry
+
+Check `.claude-plugin/marketplace.json` contains entry:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "<plugin-name>",
+      "source": "./plugins/<plugin-name>",
+      "description": "...",
+      "version": "..."
+    }
+  ]
+}
+```
+
+### 6. No Deprecated Commands
+
+Verify no `commands/` directory exists (commands merged into skills in Claude Code 2.1.3+)
+
+## Output Format
+
+```
+Validating plugin: <plugin-name>
+
+[PASS] Plugin structure valid
+[PASS] plugin.json valid
+[PASS] 2 skills validated
+[WARN] No agents defined (optional)
+[PASS] Marketplace entry found
+[PASS] No deprecated commands
+
+Result: VALID (5 passed, 1 warning, 0 errors)
+```
+
+Or if errors:
+
+```
+[FAIL] plugin.json missing required field: description
+[FAIL] skills/my-skill/SKILL.md missing frontmatter
+
+Result: INVALID (3 passed, 0 warnings, 2 errors)
+```


### PR DESCRIPTION
## Summary

- Add `/new-plugin` skill to scaffold plugins with correct marketplace structure
- Add `/validate-plugin` skill to check plugins against marketplace requirements
- Add `plugin-reviewer` agent for reviewing plugin submissions
- Add PreToolUse hook to warn when editing marketplace.json
- Enable superpowers-developing-for-claude-code plugin

## Test plan

- [ ] Run `/new-plugin test-plugin` and verify structure is created correctly
- [ ] Run `/validate-plugin productpowers` and verify validation output
- [ ] Edit marketplace.json and verify hook warning appears