### PR TITLE
Update productpowers plugin metadata and skill frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "productpowers",
       "source": "./plugins/productpowers",
       "description": "ProductPowers agent and skills library",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ]
 }

--- a/plugins/productpowers/skills/agent-browser/SKILL.md
+++ b/plugins/productpowers/skills/agent-browser/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-browser
 description: Browser automation using Vercel's agent-browser CLI. Use when you need to interact with web pages, fill forms, take screenshots, extract data, or test web applications. Uses ref-based element selection from accessibility snapshots. Alternative to Playwright MCP for Bash-based workflows.
+user-invocable: true
 ---
 
 # agent-browser: CLI Browser Automation

--- a/plugins/productpowers/skills/fix-code-review-feedback/SKILL.md
+++ b/plugins/productpowers/skills/fix-code-review-feedback/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: fix-code-review-feedback
 description: "FIX existing feedback, not generate reviews. Use AFTER a code review agent provides feedback (auto-invoke), OR manually invoke to address GitHub PR comments. Defaults to current branch's PR, or provide specific feedback URL for targeted mode. Evaluates validity (reviewers can be wrong), fixes everything valid."
+user-invocable: true
+context: fork
 ---
 
 # fix-code-review-feedback


### PR DESCRIPTION
## Summary
- Sync marketplace.json version to 0.2.0 to match plugin.json
- Add `user-invocable: true` to agent-browser skill
- Add `user-invocable: true` and `context: fork` to fix-code-review-feedback skill

## Test plan
- [ ] Verify plugin validates with `/validate-plugin productpowers`
- [ ] Confirm skills are user-invocable via `/` menu