### PR TITLE
Enforce test creation across planning and implementation workflow

### DIFF
--- a/plugins/iterative-engineering/agents/task-worker.md
+++ b/plugins/iterative-engineering/agents/task-worker.md
@@ -49,7 +49,18 @@ You receive:
 - Run the plan's `**Verify:**` step to confirm it works
 - No failing test required, but run existing tests to verify nothing broke
 
-### 3. Complete
+### 3. Verify Tests (feature subtasks only)
+
+Before committing, verify that tests were actually written:
+
+- Check that the test file listed in the plan's `**Files:**` field exists
+- Check that each test scenario from the plan's `**Test scenarios:**` has a corresponding test case
+- Run the tests and confirm they pass
+- If no tests were written for a feature subtask: **stop and write the tests before committing**. This is a hard gate — feature subtasks do not ship without tests.
+
+Non-feature subtasks (config, refactoring, infrastructure) skip this gate but still run existing tests to verify nothing broke.
+
+### 4. Complete
 
 - Stage only files related to this subtask: `git add [files]`
 - Commit with conventional format: `git commit -m "feat(scope): [subtask description]"`
@@ -64,7 +75,8 @@ Return concise completion status:
 Completed: [subtask title]
 Commit: [sha]
 Files: [list of modified files]
-Tests: [pass count]
+Tests: [pass count] ([N] new tests written, [M] plan scenarios covered)
+Test file: [path to test file, or "N/A — non-feature subtask"]
 HZL: updated (if applicable)
 ```
 
@@ -91,5 +103,6 @@ Stop and report if:
 - Plan description is unclear or ambiguous
 - Referenced files or dependencies are missing
 - Tests fail and fix isn't obvious
+- Feature subtask has no test file specified in the plan — ask the lead for the test file path before proceeding
 - Subtask seems larger than expected
 - Conflicts with other code

--- a/plugins/iterative-engineering/skills/implementing/SKILL.md
+++ b/plugins/iterative-engineering/skills/implementing/SKILL.md
@@ -47,13 +47,14 @@ Read the plan critically, create tasks, and implement with TDD, code review, and
    - Subtask number and title
    - Parent task context
    - Task system (HZL or built-in tasks) and task ID if HZL
-4. Worker reads subtask from plan, loads referenced patterns, implements, commits, and updates task status (see task-worker agent for details).
+4. Worker reads subtask from plan, loads referenced patterns, implements with TDD (tests first), commits, and updates task status (see task-worker agent for details).
 5. **Wait for batch completion.** All subagents in the batch must finish before the next batch starts.
-6. **Incremental review (large sections only).** If the plan section has more than 5 subtasks, automatically run a quick code review after each batch — this catches issues before subsequent batches build on flawed code. Scope the review to `git diff <section-baseline-sha>..HEAD`. If issues are found, present them with severity acceptance before continuing. If clean, continue to the next batch silently.
-7. **Repeat** steps 3-6 for remaining batches.
-8. Update plan document progress (mark completed items).
-9. Mark section complete in task system.
-10. **Final code review.** Run after all subtasks in the plan section are complete, regardless of whether incremental reviews occurred (see When to Review table for trivial exceptions). Scope: `git diff <section-baseline-sha>..HEAD`. Pass the baseline SHA and plan context to the `code-review` skill.
+6. **Test verification gate.** After each batch completes, verify that feature subtasks produced test files. For each completed feature subtask, check: does the test file listed in the plan's `**Files:**` field exist, and does it contain tests matching the plan's `**Test scenarios:**`? If a feature subtask committed without tests, flag it immediately — do not continue to the next batch until resolved.
+7. **Incremental review (large sections only).** If the plan section has more than 5 subtasks, automatically run a quick code review after each batch — this catches issues before subsequent batches build on flawed code. Scope the review to `git diff <section-baseline-sha>..HEAD`. If issues are found, present them with severity acceptance before continuing. If clean, continue to the next batch silently.
+8. **Repeat** steps 3-7 for remaining batches.
+9. Update plan document progress (mark completed items).
+10. Mark section complete in task system.
+11. **Final code review.** Run after all subtasks in the plan section are complete, regardless of whether incremental reviews occurred (see When to Review table for trivial exceptions). Scope: `git diff <section-baseline-sha>..HEAD`. Pass the baseline SHA and plan context to the `code-review` skill.
 
 ### Phase 3: Finish
 
@@ -188,6 +189,7 @@ If reality diverges from the plan during implementation:
 | Skipping clarification to start faster | Ask questions now — building the wrong thing is slower |
 | Creating tasks before understanding the plan | Read and clarify the plan, then create tasks |
 | Committing with failing tests | Only commit when tests pass |
+| Committing feature subtask without writing tests | TDD: write tests first from plan's test scenarios, then implement |
 | Pushing through when blocked | Stop and ask for help |
 | Full code review on trivial changes | Scale review to complexity — skip for config changes |
 | Modifying the plan silently | Report divergence and get user agreement |

--- a/plugins/iterative-engineering/skills/tech-planning/SKILL.md
+++ b/plugins/iterative-engineering/skills/tech-planning/SKILL.md
@@ -22,9 +22,10 @@ If requirements are vague and no PRD exists, offer to start with `iterative:brai
 1. **Understand before structuring** — Explore the codebase and ask questions before writing the plan
 2. **Decisions, not code** — Capture architecture choices, query strategies, component boundaries, trade-offs. Leave method names, signatures, and implementation code to the implementer
 3. **Concrete test scenarios** — Specific inputs, expected outputs, edge cases to cover. Not full test code, not "test that it works"
-4. **Right-sized subtasks** — Scoped to a single atomic commit, typically touching 2-3 files. Not too big (5+ files, multiple unrelated changes), not too small (single line, no meaningful test)
-5. **Dependencies clear** — Explicit ordering of what depends on what
-6. **Verification built-in** — Each subtask has a way to confirm it works
+4. **Test files are explicit** — Every feature subtask must include the test file path in its `**Files:**` field. Test scenarios without a target test file get skipped during implementation
+5. **Right-sized subtasks** — Scoped to a single atomic commit, typically touching 2-3 files. Not too big (5+ files, multiple unrelated changes), not too small (single line, no meaningful test)
+6. **Dependencies clear** — Explicit ordering of what depends on what
+7. **Verification built-in** — Each subtask has a way to confirm it works
 
 ## Plan Quality Bar
 
@@ -33,6 +34,7 @@ Every plan must contain:
 - **File paths** — Which files to create or modify
 - **Decisions with rationale** — Architecture choices, query strategies, data flow, what was considered and rejected
 - **Test scenarios** — Specific inputs, expected outputs, edge cases — not "verify it works"
+- **Test file paths** — Every feature subtask includes the test file in `**Files:**` — no test file = tests won't get written
 - **Existing patterns to follow** — Reference actual code in the codebase that the implementer should use as a model
 - **What and why, not how** — Describe what each subtask accomplishes and the key decisions driving it. Don't pre-write the implementation
 
@@ -61,7 +63,7 @@ A plan is ready when an implementer can start working without asking clarifying 
 1. Identify major components (become parent tasks, typically 2-5).
 2. Break each into subtasks (2-5 per parent, one commit each).
 3. Use the standardized subtask format (see template) — every subtask has the same fields so it can be directly converted into tasks.
-4. For each subtask, define: dependencies on other subtasks (always present, even if "none"), files to create or modify, what the subtask accomplishes and key decisions, test scenarios with specific inputs and expected outputs, how to verify it works.
+4. For each subtask, define: dependencies on other subtasks (always present, even if "none"), files to create or modify (including test files for feature subtasks), what the subtask accomplishes and key decisions, test scenarios with specific inputs and expected outputs, how to verify it works.
 5. Number subtasks as Parent.Subtask (1.1, 1.2, 2.1) for cross-referencing.
 
 ### Phase 3: Write Technical Plan
@@ -106,6 +108,7 @@ The tech plan's `**PRD:**` header links to the PRD document. If the PRD is updat
 | Vague descriptions ("implement the feature") | Specific: what to build, which files, what decisions, what edge cases |
 | Pre-writing implementation code in the plan | Describe what to build and the decisions; the implementer writes the code |
 | Test descriptions without specifics ("test that it works") | Concrete scenarios: specific inputs, expected outputs, edge cases |
+| Test scenarios without a test file in `Files:` | Every feature subtask includes the test file path — no test file = tests won't get written |
 | Planning without referencing existing code patterns | Ground every subtask in actual file paths and existing conventions |
 | Over-planning hypothetical scenarios | Plan only what's needed; defer decisions that can wait |
 | Diverging from the PRD without updating it | Update the PRD when approach changes — it's the requirements source of truth |

--- a/plugins/iterative-engineering/skills/tech-planning/references/tech-plan-template.md
+++ b/plugins/iterative-engineering/skills/tech-planning/references/tech-plan-template.md
@@ -35,13 +35,15 @@ Every subtask uses the same standardized format so it can be directly converted 
 [What this subtask accomplishes — the change, approach, key decisions,
 rationale. Free-form but specific enough to act on without clarifying questions.]
 
-**Test scenarios:**
+**Test scenarios:** (`path/to/test.test.ts`)
 - [Input/condition] → [expected output/behavior]
 - [Edge case] → [expected handling]
 - [Error case] → [expected error]
 
 **Verify:** [How to confirm it works]
 ```
+
+**Important:** Feature subtasks must include the test file path in both `**Files:**` and `**Test scenarios:**`. The parenthetical after "Test scenarios:" tells the implementer exactly where to write the tests. Without it, test scenarios get skipped.
 
 ```markdown
 #### 1.2 [Action-oriented title]
@@ -62,7 +64,7 @@ rationale. Free-form but specific enough to act on without clarifying questions.
 - **Depends on** — Always present. Use subtask numbers (e.g., `1.1, 2.3`) or `none`. These become task dependencies during conversion
 - **Files** — File paths to create or modify. Become task links during conversion
 - **Description** — Everything the implementer needs: what, why, approach, patterns to follow. Reference PRD requirement numbers (e.g., "Satisfies requirement #2") when a subtask directly fulfills a PRD requirement — this enables downstream validation during code review
-- **Test scenarios** — Concrete inputs → expected outputs
+- **Test scenarios** — Concrete inputs → expected outputs. Parenthetical names the test file (e.g., `**Test scenarios:** (path/to/test.test.ts)`)
 - **Verify** — How to confirm the subtask works
 
 ### Closing Sections
@@ -121,7 +123,7 @@ Standalone method rather than extending `getSubtasks()` — keeps it
 unchanged and composable for other callers. The existing `getBlockedByMap()`
 only covers `ready` status which is too narrow — need all non-terminal statuses.
 
-**Test scenarios:**
+**Test scenarios:** (`packages/hzl-core/src/services/task-service.test.ts`)
 - Empty input → empty map
 - Tasks with no dependencies → empty map
 - Tasks with incomplete dependencies → map of task_id to blocking dep IDs
@@ -148,6 +150,7 @@ Before the plan is complete, verify every subtask has:
 - [ ] Description specific enough to act on without clarifying questions
 - [ ] Key decisions with rationale (approach, query strategy, data flow)
 - [ ] Concrete test scenarios with specific inputs and expected outputs
+- [ ] Test file path in `Files:` and parenthetical in `Test scenarios:` (feature subtasks)
 - [ ] Reference to existing patterns to follow (where applicable)
 
 And the plan overall has:


### PR DESCRIPTION
## Summary

- Plans now require test file paths in every feature subtask's `Files:` field and a parenthetical on `Test scenarios:` naming the target test file
- The implementing skill adds a test verification gate after each batch that blocks progress until feature subtasks have tests
- The task-worker agent has a hard pre-commit check that stops feature subtasks from shipping without tests

## Test plan

- [ ] Run a tech-planning session and verify the plan output includes test file paths in `Files:` and parenthetical in `Test scenarios:`
- [ ] Run an implementing session and verify the test verification gate fires after batch completion
- [ ] Verify task-worker stops before committing if no tests were written for a feature subtask