### PR TITLE
Add install script for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,42 @@ Claude Code plugins by Trevin Chow.
 
 [trev.in](https://trev.in) · [LinkedIn](https://linkedin.com/in/trevin)
 
-## Installation
+## Quick Install
 
-### 1. Add the marketplace
+```bash
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
+```
+
+Installs the Claude Code plugin and Codex skills. Safe to re-run (idempotent). Skips anything not detected (e.g., no Codex installed).
+
+To uninstall:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --uninstall
+```
+
+## Manual Install
+
+### Claude Code
 
 ```
 /plugin marketplace add tmchow/tmc-marketplace
-```
-
-### 2. Install a plugin
-
-```
 /plugin install iterative-engineering@tmc-marketplace
 ```
 
-### 3. Verify installation
+Verify with `/plugin list`.
 
+### Codex
+
+Download the skills into your Codex skills directory:
+
+```bash
+curl -sL https://github.com/tmchow/tmc-marketplace/archive/refs/heads/main.tar.gz \
+  | tar xz --strip-components=4 -C ~/.codex/skills/ \
+    tmc-marketplace-main/plugins/iterative-engineering/skills/
 ```
-/plugin list
-```
+
+This extracts all skills (with their reference files) to `~/.codex/skills/`.
 
 ## Plugins
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TMC Marketplace Installer
+# Usage:
+#   Install:   curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
+#   Uninstall: curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --uninstall
+
+# --- Constants ---
+VERSION="1.0.0"
+REPO="tmchow/tmc-marketplace"
+PLUGIN_NAME="iterative-engineering"
+MARKETPLACE_NAME="tmc-marketplace"
+ARCHIVE_URL="https://github.com/${REPO}/archive/refs/heads/main.tar.gz"
+ARCHIVE_PREFIX="tmc-marketplace-main"
+MAX_RETRIES=3
+RETRY_DELAY=2
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# --- State ---
+UNINSTALL=false
+LAST_DOWNLOAD_ERROR=""
+
+# --- Utility functions ---
+
+log_info() {
+    echo -e "${BLUE}[tmc]${NC} $1" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC} $1" >&2
+}
+
+log_warn() {
+    echo -e "${YELLOW}⚠${NC} $1" >&2
+}
+
+log_error() {
+    echo -e "${RED}✗${NC} $1" >&2
+}
+
+print_details() {
+    local output="$1"
+    echo -e "  ${YELLOW}→${NC} Details:" >&2
+    while IFS= read -r line; do
+        echo "    $line" >&2
+    done <<< "$output"
+}
+
+die() {
+    log_error "$1"
+    exit 1
+}
+
+download_with_retry() {
+    local url="$1"
+    local dest="$2"
+    local attempt=1
+
+    LAST_DOWNLOAD_ERROR=""
+    while [ $attempt -le $MAX_RETRIES ]; do
+        local output
+        if output=$(curl -fsSL -S "$url" -o "$dest" 2>&1); then
+            return 0
+        fi
+        LAST_DOWNLOAD_ERROR="$output"
+        if [ $attempt -lt $MAX_RETRIES ]; then
+            log_warn "Download failed, retrying in ${RETRY_DELAY}s... (attempt $attempt/$MAX_RETRIES)"
+            sleep $RETRY_DELAY
+        fi
+        ((attempt++))
+    done
+    return 1
+}
+
+# --- Core functions ---
+
+print_banner() {
+    echo -e "${BOLD}${BLUE}"
+    echo "╔════════════════════════════════════════╗"
+    echo "║       TMC Marketplace Installer        ║"
+    echo "╚════════════════════════════════════════╝"
+    echo -e "${NC}"
+}
+
+install_claude_plugin() {
+    log_info "Installing Claude Code plugin..."
+
+    if ! command -v claude &>/dev/null; then
+        log_warn "Claude Code CLI not found, skipping plugin install"
+        echo -e "  ${YELLOW}→${NC} After installing Claude Code, re-run this script to add the plugin" >&2
+        return 0
+    fi
+
+    # Add marketplace (idempotent; may return non-zero if already added)
+    local marketplace_output
+    if ! marketplace_output=$(claude plugin marketplace add "${REPO}" 2>&1); then
+        log_warn "Failed to add marketplace (may already exist), continuing"
+        print_details "$marketplace_output"
+    fi
+
+    # Install plugin (idempotent - reinstalls/updates if exists)
+    local install_output
+    if ! install_output=$(claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}" 2>&1); then
+        log_warn "Failed to install plugin"
+        print_details "$install_output"
+        return 0
+    fi
+
+    log_success "Installed ${PLUGIN_NAME}@${MARKETPLACE_NAME} plugin"
+}
+
+install_codex_skills() {
+    log_info "Installing Codex skills..."
+
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+
+    if [ ! -d "$codex_home" ]; then
+        log_warn "Codex not detected (~/.codex/ not found), skipping skill install"
+        echo -e "  ${YELLOW}→${NC} After installing Codex, re-run this script to add the skills" >&2
+        return 0
+    fi
+
+    local skills_dir="${codex_home}/skills"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    # Download archive
+    local archive_path="${tmp_dir}/archive.tar.gz"
+    if ! download_with_retry "$ARCHIVE_URL" "$archive_path"; then
+        rm -rf "$tmp_dir"
+        log_warn "Failed to download skills after $MAX_RETRIES attempts"
+        if [ -n "$LAST_DOWNLOAD_ERROR" ]; then
+            print_details "$LAST_DOWNLOAD_ERROR"
+        fi
+        return 0
+    fi
+
+    # Extract
+    local extract_dir="${tmp_dir}/extracted"
+    mkdir -p "$extract_dir"
+    tar xzf "$archive_path" -C "$extract_dir"
+
+    local source_skills="${extract_dir}/${ARCHIVE_PREFIX}/plugins/${PLUGIN_NAME}/skills"
+    if [ ! -d "$source_skills" ]; then
+        rm -rf "$tmp_dir"
+        log_warn "Skills directory not found in archive"
+        return 0
+    fi
+
+    # Copy each skill and record in manifest
+    local manifest="${skills_dir}/.tmc-marketplace"
+    local count=0
+    local installed_skills=()
+
+    for skill_dir in "$source_skills"/*/; do
+        [ -d "$skill_dir" ] || continue
+        local skill_name
+        skill_name=$(basename "$skill_dir")
+        local dest="${skills_dir}/${skill_name}"
+
+        rm -rf "$dest"
+        cp -r "$skill_dir" "$dest"
+        installed_skills+=("$skill_name")
+        ((count++))
+    done
+
+    # Write manifest for clean uninstall
+    printf '%s\n' "${installed_skills[@]}" > "$manifest"
+
+    rm -rf "$tmp_dir"
+    log_success "Installed ${count} skills to ${skills_dir}/"
+}
+
+print_success() {
+    echo ""
+    echo -e "${GREEN}${BOLD}Done!${NC}"
+    echo ""
+}
+
+# --- Uninstall functions ---
+
+do_uninstall() {
+    log_info "Uninstalling TMC Marketplace..."
+    echo ""
+
+    # Remove Claude Code plugin
+    if command -v claude &>/dev/null; then
+        log_info "Removing Claude Code plugin..."
+
+        local uninstall_output
+        if uninstall_output=$(claude plugin uninstall "${PLUGIN_NAME}@${MARKETPLACE_NAME}" 2>&1); then
+            log_success "Removed Claude Code plugin"
+        else
+            log_warn "Claude Code plugin not found or failed to remove"
+            print_details "$uninstall_output"
+        fi
+
+        local remove_output
+        if remove_output=$(claude plugin marketplace remove "${REPO}" 2>&1); then
+            log_success "Removed marketplace"
+        else
+            log_warn "Marketplace not found or failed to remove"
+            print_details "$remove_output"
+        fi
+    fi
+
+    # Remove Codex skills
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local skills_dir="${codex_home}/skills"
+    local manifest="${skills_dir}/.tmc-marketplace"
+
+    if [ -f "$manifest" ]; then
+        log_info "Removing Codex skills..."
+        local removed=0
+
+        while IFS= read -r skill_name; do
+            [ -z "$skill_name" ] && continue
+            local skill_dir="${skills_dir}/${skill_name}"
+            if [ -d "$skill_dir" ]; then
+                rm -rf "$skill_dir"
+                ((removed++))
+            fi
+        done < "$manifest"
+
+        rm -f "$manifest"
+        log_success "Removed ${removed} Codex skills"
+    fi
+
+    echo ""
+}
+
+# --- Argument parsing ---
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --uninstall)
+                UNINSTALL=true
+                shift
+                ;;
+            --help|-h)
+                echo "TMC Marketplace Installer v${VERSION}"
+                echo ""
+                echo "Usage:"
+                echo "  Install:   curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash"
+                echo "  Uninstall: curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --uninstall"
+                echo ""
+                echo "Options:"
+                echo "  --uninstall    Remove plugin and skills"
+                echo "  --help, -h     Show this help message"
+                exit 0
+                ;;
+            *)
+                die "Unknown option: $1. Use --help for usage."
+                ;;
+        esac
+    done
+}
+
+# --- Main ---
+
+main() {
+    parse_args "$@"
+    print_banner
+
+    if [[ "$UNINSTALL" == "true" ]]; then
+        do_uninstall
+    else
+        install_claude_plugin
+        install_codex_skills
+        print_success
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/install.sh` — one-liner installer modeled after [tmchow/hzl](https://github.com/tmchow/hzl/blob/main/scripts/install.sh) install script
- Claude Code: adds marketplace + installs plugin via `claude plugin` CLI
- Codex: downloads repo tarball and extracts all 11 skills (with reference files) to `~/.codex/skills/`
- Includes `--uninstall` support with manifest-based cleanup
- Updates README with quick install and manual install sections for both tools

## Test plan

- [ ] Run install script with Claude Code installed — verify plugin appears in `/plugin list`
- [ ] Run install script with `~/.codex/` present — verify skills extracted correctly
- [ ] Run install script without Claude Code / Codex — verify graceful skip with helpful message
- [ ] Run `--uninstall` — verify clean removal of plugin and skills
- [ ] Run install script twice — verify idempotent behavior
- [ ] Verify manual Codex install command from README works