### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "iterative-engineering",
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
-      "version": "1.2.0"
+      "version": "1.3.0"
     }
   ]
 }

--- a/plugins/iterative-engineering/.claude-plugin/plugin.json
+++ b/plugins/iterative-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iterative-engineering",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Iterative development workflows. 13 agents, 11 skills for brainstorming, research, spiking, tech planning, multi-agent reviews, TDD execution, and PR feedback resolution.",
   "author": {
     "name": "Trevin Chow",

--- a/plugins/iterative-engineering/CHANGELOG.md
+++ b/plugins/iterative-engineering/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the iterative-engineering plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-02-08
+
+### Added
+
+- **Install script** — one-liner `curl | bash` installer for both Claude Code (plugin marketplace) and Codex (skill files). Includes `--uninstall`, retry logic, and idempotent operations.
+- **Codex support** — skills now installable to `~/.codex/skills/` via tarball extraction, with manifest-based cleanup on uninstall.
+
+---
+
 ## [1.2.0] - 2026-02-08
 
 ### Added


### PR DESCRIPTION
## Summary

- Bump version 1.2.0 → 1.3.0 (minor)
- Add changelog entry for install script and Codex support

After merge, tag with `git tag v1.3.0 && git push --tags`.