### PR TITLE
Restructure spike skill for clarity and reliability

### DIFF
--- a/plugins/iterative-engineering/skills/spike/SKILL.md
+++ b/plugins/iterative-engineering/skills/spike/SKILL.md
@@ -21,7 +21,7 @@ This skill resolves unknowns where the answer **needs to be built and experience
 
 1. **Validate, don't implement** — The spike answers a question. It's not a head start on implementation. No tests, no error handling, no edge cases.
 2. **Minimum to validate** — Build the least amount needed to answer the question. Resist the urge to flesh things out.
-3. **Separation of throwaway and durable** — In-codebase spike code goes in a separate worktree (throwaway). Spike docs, PRD updates, and static HTML prototypes go on the original branch (durable).
+3. **Throwaway code, durable docs** — In-codebase spike code goes in a separate worktree and is deleted when the spike ends. Spike docs and PRD updates go on the original branch and persist. Static HTML prototypes are preserved in the spike directory by default.
 4. **Spike doc captures the journey; PRD captures conclusions** — If a PRD exists, it gets updated with full rationale — self-sufficient for downstream stages without needing to read the spike doc. For standalone spikes, the spike doc itself is the primary output.
 5. **User drives iteration** — Build, present, get feedback, iterate. The user decides when they've seen enough.
 
@@ -41,40 +41,38 @@ This skill resolves unknowns where the answer **needs to be built and experience
 
 ### Phase 1: Scope the Spike
 
+**What to validate**
+
 1. **Identify what to validate.** If invoked from brainstorming, the open questions provide context. If standalone, ask the user what they want to validate.
 2. **Map to requirements.** If a PRD exists, connect the spike to specific requirements or decisions being validated.
 3. **Define the validation goal.** What are we trying to learn? What outcome would change direction? Frame it as understanding to gain, not a decision to make (see spike doc template for acceptance guidelines).
-4. **Assess system state and spike medium.** Two factors shape the approach:
 
-   **System state** determines where spike code lives:
+**How to build it**
 
-   | System state | Approach |
-   |---|---|
-   | Relevant modules exist and work | **Spike within** — add minimal code to existing system. Validates in real context. |
-   | System exists but relevant parts aren't built yet | **Standalone prototype** — build outside the system. Cheaper than integrating. |
-   | Greenfield or very early | **Standalone prototype** — minimal app, script, whatever fits the question. |
+4. **Determine spike medium.** First assess: can we spike within the existing system? (Relevant modules exist and work.)
 
-   **Spike medium** determines how prototypes are built. The system state drives whether to ask or default:
-
-   - **System doesn't support spiking within** (standalone prototype or greenfield): default to static HTML and proceed. No need to ask — in-codebase isn't viable.
-   - **System supports spiking within** (relevant modules exist and work): ask the user which medium they prefer:
+   - **If no** (greenfield, or relevant parts aren't built yet): default to **static HTML** and proceed. In-codebase isn't viable, so no need to ask.
+   - **If yes**: ask the user which medium fits:
 
    | Medium | When it fits |
    |---|---|
    | **In-codebase** | Validating behavior that depends on real data, system integration, or existing UI. Uses a worktree. Code is throwaway. |
-   | **Static HTML** | Validating visual design, UX flow, interaction feel, or comparing multiple variants side-by-side. Self-contained HTML files preserved in the spike directory. No worktree needed. |
+   | **Static HTML** | Validating visual design, UX flow, interaction feel, or comparing multiple variants side-by-side. Self-contained HTML files in the spike directory. |
    | **Both** | Some questions need real system context, others need rapid visual exploration. Worktree for integration, static HTML for visual variants. |
 
-   Default recommendation when asking: if the validation goal is primarily visual/UX and doesn't need live data, suggest static HTML.
+   Default recommendation: if the validation goal is primarily visual/UX and doesn't need live data, suggest static HTML.
 
-5. **Ask about multiple approaches.** "Do you want to explore multiple approaches, or start with one and see?" If multiple, note the planned variants. Variants can also be added later during Phase 3 — this question sets intent, not a rigid plan.
+5. **Discuss approaches.** Ask whether the user wants to explore multiple approaches upfront or start with one. If multiple, note the planned variants. Either way, additional approaches can always be added later during Phase 3 — this sets initial intent, not a rigid plan.
+
+**Document and confirm**
+
 6. **Create the spike doc on the original branch.** Use the template in `references/spike-template.md`. Save to `docs/spikes/YYYY-MM-DD-<topic>/spike.md` (ensure directory exists). Fill in Context, Validation Goal, and Approach. Status: In Progress. Create this before Phase 2 setup — the spike doc is a durable artifact that belongs on the original branch, not a throwaway spike branch.
 7. **Present the scope to the user.** What we're validating, how we'll build it, what we're deliberately leaving out. Get confirmation before setup.
 
 ### Phase 2: Setup
 
 1. **If the spike includes in-codebase work:** Invoke the `git-worktree` skill with branch name `spike/<topic>`. In-codebase spike code is throwaway and should not mix with feature or main branch work. Record worktree info in the spike doc's Spike Code section. A single worktree can hold multiple approach variants — use separate files, components, or routes so variants coexist and are independently runnable.
-2. **If the spike includes static HTML prototypes:** Create `docs/spikes/YYYY-MM-DD-<topic>/prototypes/` on the original branch. HTML prototypes are durable artifacts — they live alongside the spike doc, not in a worktree.
+2. **If the spike includes static HTML prototypes:** Create `docs/spikes/YYYY-MM-DD-<topic>/prototypes/` on the original branch. HTML prototypes live alongside the spike doc, not in a worktree.
 3. **Commit durable artifacts as they're written.** Spike doc, HTML prototypes, and upstream doc updates live on the original branch — commit them incrementally, don't leave them as uncommitted changes. This protects against accidental loss from stash, reset, or checkout operations on the original branch. Small, frequent commits are fine; the "In Progress" status makes it clear the spike is still in flight.
 4. **Minimal setup only.** No test infrastructure, no CI config. Just enough to build and demonstrate.
 
@@ -84,10 +82,14 @@ This skill resolves unknowns where the answer **needs to be built and experience
    - **For static HTML prototypes:** Each file should be self-contained (inline styles and scripts). Name files descriptively: `v1-sidebar-nav.html`, `v2-top-nav.html`. Create multiple variants when comparing approaches — this is a key advantage of the static HTML medium.
    - **For in-codebase variants:** Build each approach as separate files, components, or routes within the same worktree so the user can compare them side-by-side in the running app (e.g., `/nav-v1` and `/nav-v2`, or toggling between components).
 2. **Present to the user.** How to experience the spike depends on what was built — open a file in a browser, run a server, execute a command, walk through the behavior. Be specific about how the user can see or interact with it.
-3. **Ask targeted feedback questions.** Not open-ended "what do you think?" — specific questions tied to the validation goal. Examples:
-   - "Does this drag interaction feel natural, or does it fight you?"
-   - "Is this the information hierarchy you expected on this screen?"
-   - "When you [performed action], was the result what you anticipated?"
+3. **Gather feedback.** This is a dialogue, not a single round of questions.
+   - Start with 1-2 targeted questions tied to the validation goal. Not open-ended "what do you think?" — specific questions. Examples:
+     - "Does this drag interaction feel natural, or does it fight you?"
+     - "Is this the information hierarchy you expected on this screen?"
+     - "When you [performed action], was the result what you anticipated?"
+   - Let the user respond freely — they may raise points you didn't ask about.
+   - Follow up on their responses. Dig into what's working and what isn't.
+   - Continue until the user's reaction is clear. Don't rush to the "what's next" options.
 4. **Update the spike doc's Progress section** with a brief note: what was built, key feedback, what's next. Write this to the original branch path, not the worktree — the spike doc's canonical location is on the original branch.
 5. **User chooses:**
    - **Iterate** — refine the current approach based on feedback, return to step 1
@@ -103,7 +105,7 @@ This skill resolves unknowns where the answer **needs to be built and experience
    - Write Decisions: what changed, what was validated, requirement confirmations or changes
    - If the spike was abandoned/inconclusive: document what was tried and why it didn't resolve the uncertainty. Carry the question forward.
    - Remove the Progress section (fold relevant content into Findings)
-   - Set Status to Complete
+   - Set Status to `Complete` or `Abandoned` based on how the spike concluded
 
 2. **Propose upstream doc updates.** If a PRD exists, propose specific changes using the mapping in `references/prd-update-guide.md`. If no PRD or tech plan exists (standalone spike), skip to step 5.
 
@@ -112,6 +114,10 @@ This skill resolves unknowns where the answer **needs to be built and experience
 4. **Apply approved changes** to the PRD (and tech plan if applicable) on the original branch. Each change in the PRD should include enough context that someone reading it understands the decision without reading the spike doc. The spike doc updates (Findings, Decisions, Impact, Status) also go on the original branch.
 
 5. **Write Impact on Upstream Docs section** in spike doc: summarize what was changed in upstream docs, or note "Standalone spike — no upstream docs."
+
+6. **Clean up throwaway artifacts.**
+   - **In-codebase spikes:** Remove the spike worktree and delete the spike branch. All durable artifacts (spike doc, PRD updates) are already on the original branch — nothing is lost. Use the `git-worktree` skill or `git worktree remove` directly.
+   - **Static HTML prototypes:** Preserved in `docs/spikes/` alongside the spike doc. No cleanup needed.
 
 ### Phase 5: Handoff
 
@@ -128,10 +134,11 @@ For handling unusual situations during spikes, consult `references/edge-cases.md
 - When the spike invalidates the PRD direction
 - Coordinating multiple spikes from brainstorming
 - When things go wrong (unclear goals, non-converging spikes, worktree failures)
+- Cleanup issues (uncommitted worktree changes, missing worktrees)
 
 ## Anti-Patterns
 
-Consult `references/anti-patterns.md` for common mistakes. Key ones: don't build production-quality code in a spike, don't spike on the main branch, and don't put HTML prototypes in the worktree.
+Consult `references/anti-patterns.md` for common mistakes. Key ones: don't build production-quality code in a spike, don't spike on the main branch, don't put HTML prototypes in the worktree, and don't leave spike worktrees around after the spike ends.
 
 ## Transition Points
 

--- a/plugins/iterative-engineering/skills/spike/references/anti-patterns.md
+++ b/plugins/iterative-engineering/skills/spike/references/anti-patterns.md
@@ -5,9 +5,11 @@
 | Building production-quality code in a spike | Deliberately rough — no tests, no error handling. It's throwaway. |
 | Spiking on the main or feature branch | In-codebase spikes always use a worktree. Static HTML prototypes go in `docs/spikes/` on the original branch. |
 | Putting HTML prototypes in the worktree | HTML prototypes are durable artifacts — they belong in `docs/spikes/YYYY-MM-DD-<topic>/prototypes/`, not the throwaway worktree. |
-| Open-ended "what do you think?" feedback | Targeted questions tied to the validation goal |
+| Leaving spike worktrees around after the spike ends | Phase 4 cleanup removes the worktree and branch. All durable artifacts are on the original branch — the worktree is pure throwaway. |
+| Open-ended "what do you think?" feedback | Targeted questions tied to the validation goal, followed by open dialogue |
+| Treating feedback as a single round | Feedback is a dialogue — ask, listen, follow up. Don't rush to "what's next" after one question. |
 | Updating PRD with "see spike doc" as rationale | Full reasoning in the PRD — it must be self-sufficient for downstream stages |
 | Forcing conclusions from an inconclusive spike | Document what was tried, carry the uncertainty forward |
-| Deleting the spike worktree before the spike is complete | Worktree persists until the user is done — the spike skill owns the lifecycle |
+| Deleting the spike worktree before the spike is complete | Worktree persists until Phase 4 cleanup — the spike skill owns the lifecycle |
 | Scope creep — adding features beyond the validation goal | Build the minimum to answer the question. If new questions emerge, scope them as separate spikes. |
 | Spiking questions that research could answer | If the answer exists somewhere, use `iterative:research` instead |

--- a/plugins/iterative-engineering/skills/spike/references/edge-cases.md
+++ b/plugins/iterative-engineering/skills/spike/references/edge-cases.md
@@ -23,6 +23,17 @@ When brainstorming identifies several spike-worthy questions:
 
 Each spike gets its own directory, its own doc, and — for in-codebase spikes — its own worktree and branch.
 
+## Cleanup Issues
+
+**Worktree has uncommitted changes at cleanup time:**
+- Don't silently discard. Ask the user: "The spike worktree has uncommitted changes. These are throwaway by design — OK to delete, or do you want to review first?"
+- If the user wants to keep something, they can cherry-pick or copy files to the original branch before cleanup.
+
+**Spike doc references a worktree that no longer exists:**
+- The worktree may have been manually removed or lost. Flag the inconsistency during Phase 0 resume detection.
+- If the spike is still in progress, offer to recreate the worktree from the spike branch (if it still exists) or start fresh.
+- If the spike is being concluded, proceed with Phase 4 — the worktree isn't needed for documentation.
+
 ## When Things Go Wrong
 
 **Stop and ask for clarification when:**


### PR DESCRIPTION
## Summary

- Organizes Phase 1 into clear sub-groups (what to validate / how to build it / document and confirm) to reduce cognitive load on the overloaded scoping phase
- Simplifies the medium decision from a nested two-table structure to a single yes/no gate with the same logic
- Reworks Phase 3 feedback step from a single round of targeted questions to an explicit interactive dialogue (ask, listen, follow up)
- Adds explicit worktree cleanup step to Phase 4 wrap-up, closing the gap where throwaway artifacts lingered after spike completion
- Fixes abandoned spike status bug (was always set to `Complete`, now correctly uses `Abandoned` when applicable)
- Adds cleanup edge cases to edge-cases.md (uncommitted worktree changes, missing worktrees)
- Adds anti-patterns for lingering worktrees and treating feedback as a single round

## Test plan

- [ ] Verify spike skill invocation from brainstorming follows restructured phases correctly
- [ ] Verify standalone spike invocation follows restructured phases correctly
- [ ] Verify Phase 4 cleanup step removes worktree for in-codebase spikes
- [ ] Verify abandoned spike gets `Abandoned` status, not `Complete`