### PR TITLE
fix: auto-tag workflow permission denied error

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to the auto-tag workflow so the `GITHUB_TOKEN` can push tags
- Fixes the 403 error: `Permission to tmchow/tmc-marketplace.git denied to github-actions[bot]`

## Test plan
- [ ] Merge this PR and verify the auto-tag workflow succeeds on the next release