### PR TITLE
chore(release): 1.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "iterative-engineering",
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
-      "version": "1.3.1"
+      "version": "1.3.2"
     }
   ]
 }

--- a/plugins/iterative-engineering/.claude-plugin/plugin.json
+++ b/plugins/iterative-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iterative-engineering",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Iterative development workflows. 13 agents, 11 skills for brainstorming, research, spiking, tech planning, multi-agent reviews, TDD execution, and PR feedback resolution.",
   "author": {
     "name": "Trevin Chow",

--- a/plugins/iterative-engineering/CHANGELOG.md
+++ b/plugins/iterative-engineering/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the iterative-engineering plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-02-08
+
+### Fixed
+
+- **Auto-tag workflow** — added `contents: write` permission so the GitHub Actions token can push tags.
+
+---
+
 ## [1.3.1] - 2026-02-08
 
 ### Changed


### PR DESCRIPTION
## Summary
- Patch release for auto-tag workflow CI fix

## Changelog
- **Fixed:** Auto-tag workflow — added `contents: write` permission so the GitHub Actions token can push tags