### PR TITLE
chore(release): 1.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "iterative-engineering",
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
-      "version": "1.3.2"
+      "version": "1.3.3"
     }
   ]
 }

--- a/plugins/iterative-engineering/.claude-plugin/plugin.json
+++ b/plugins/iterative-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iterative-engineering",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Iterative development workflows. 13 agents, 11 skills for brainstorming, research, spiking, tech planning, multi-agent reviews, TDD execution, and PR feedback resolution.",
   "author": {
     "name": "Trevin Chow",

--- a/plugins/iterative-engineering/CHANGELOG.md
+++ b/plugins/iterative-engineering/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the iterative-engineering plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-02-09
+
+### Fixed
+
+- **PRD requirements format** — single markdown table (`ID | Priority | Requirement`) instead of sub-headers per priority. Shorter labels: Must-Have → Must, Nice-to-Have → Nice.
+- **Review recommendations** — always recommend "Review the PRD" on first pass; no recommendation after first review round (let user decide).
+- **Tech plan line references** — reference code by function/class/pattern name, not line numbers that drift.
+- **Doc commits** — PRDs, plans, and research updates committed at every checkpoint instead of left uncommitted across workflow stages. Branch safety gate prevents accidental commits to default branch.
+- **Implementing resume** — Phase 0 no longer skips Phase 1 setup (task creation, HZL detection, workspace isolation) when prior conversation context exists but no tasks were created. Affects both HZL and built-in task tracking.
+
+### Changed
+
+- **README** — surfaced agent teams with fallback in Reviews section and added doc-commit design decision.
+
+---
+
 ## [1.3.2] - 2026-02-08
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Bump version 1.3.2 → 1.3.3
- PRD requirements as markdown table, doc commits at checkpoints, branch safety gate, review recommendation fixes, no line numbers in tech plans, agent teams surfaced in README, implementing resume fix

Tag `v1.3.3` will be created automatically when this merges.