### PR TITLE
chore(release): 1.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "iterative-engineering",
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
-      "version": "1.3.3"
+      "version": "1.3.4"
     }
   ]
 }

--- a/plugins/iterative-engineering/.claude-plugin/plugin.json
+++ b/plugins/iterative-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iterative-engineering",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Iterative development workflows. 13 agents, 11 skills for brainstorming, research, spiking, tech planning, multi-agent reviews, TDD execution, and PR feedback resolution.",
   "author": {
     "name": "Trevin Chow",

--- a/plugins/iterative-engineering/CHANGELOG.md
+++ b/plugins/iterative-engineering/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the iterative-engineering plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-02-09
+
+### Fixed
+
+- **Redundant section review** — skip section-level code review when plan has only one section; Phase 3's final review covers the same code plus simplification.
+- **Sequential review/simplification** — Phase 3 steps are strictly sequential. Simplifier must complete before code review starts. Anti-pattern added for parallelizing code changes with review.
+- **Severity acceptance** — now a separate interaction from next-step options. All severity levels with findings are shown (not just the highest). Recommend re-review after fixes, wrap-up only when clean or skipped.
+- **Code review agent count** — emphasized spawning all 5 reviewers in Full mode to prevent launching only one.
+
+---
+
 ## [1.3.3] - 2026-02-09
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Bump version 1.3.3 → 1.3.4
- Skip redundant section review for single-section plans, enforce sequential simplification/review, fix severity acceptance as separate interaction, ensure all 5 reviewers spawn in Full mode

Tag `v1.3.4` will be created automatically when this merges.