### PR TITLE
chore(release): 1.3.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "iterative-engineering",
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
-      "version": "1.3.4"
+      "version": "1.3.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Changelog
 
-All notable changes to the iterative-engineering plugin will be documented in this file.
+All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.5] - 2026-02-09
+
+### Fixed
+
+- **Severity acceptance two-path flow** — redesigned as two prompts: accept recommended fixes (Critical+High) or choose severity levels via multi-select. Medium/Low-only reviews no longer skipped. Code-review omits Fix order when invoked from implementing to prevent competing signals. (#29)
+
+### Changed
+
+- **Changelog** — moved to repo root (repo-wide, not plugin-specific). Backfilled PR references and version comparison links per Keep a Changelog spec. (#30, #31)
+- **Conventional commits** — added commit and PR title conventions to AGENTS.md. (#31)
+
+---
 
 ## [1.3.4] - 2026-02-09
 
@@ -93,6 +106,7 @@ Initial release — 11 skills, 13 agents. (#10)
 Core workflow: brainstorming → research → spike → tech planning → implementing, with multi-agent reviews at each stage.
 
 <!-- Version comparison links -->
+[1.3.5]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.1...v1.3.2

--- a/plugins/iterative-engineering/.claude-plugin/plugin.json
+++ b/plugins/iterative-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iterative-engineering",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Iterative development workflows. 13 agents, 11 skills for brainstorming, research, spiking, tech planning, multi-agent reviews, TDD execution, and PR feedback resolution.",
   "author": {
     "name": "Trevin Chow",


### PR DESCRIPTION
## Summary
- Severity acceptance redesigned as two-path flow with fast path (accept Critical+High) and granular path (multi-select severity levels) (#29)
- Changelog moved to repo root, backfilled with PR references and version comparison links (#30, #31)
- Conventional commit conventions added to AGENTS.md (#31)

## Test plan
- [ ] Verify version bumped in plugin.json and marketplace.json
- [ ] Verify changelog entry for 1.3.5 with PR references
- [ ] Verify auto-tag creates v1.3.5 on merge