### PR TITLE
feat: add image-sprout plugin and multi-plugin infrastructure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,6 +14,12 @@
       "source": "./plugins/iterative-engineering",
       "description": "Iterative development workflow - brainstorming, planning, multi-agent reviews, TDD execution, and PR feedback resolution",
       "version": "1.15.0"
+    },
+    {
+      "name": "image-sprout",
+      "source": "./plugins/image-sprout",
+      "description": "Skill for generating and iterating on images with consistent style and subject identity using the image-sprout CLI",
+      "version": "1.0.2"
     }
   ]
 }

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,32 +15,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read version from plugin.json
-        id: version
+      - name: Detect changed plugins and create tags
         run: |
-          VERSION=$(python3 -c "import json; print(json.load(open('plugins/iterative-engineering/.claude-plugin/plugin.json'))['version'])")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Find plugin.json files changed in this push
+          CHANGED_PLUGINS=$(git diff --name-only HEAD~1 HEAD -- 'plugins/*/.claude-plugin/plugin.json' || true)
 
-      - name: Check tag and changelog
-        id: check
-        run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          VERSION="${{ steps.version.outputs.version }}"
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-            echo "should_tag=false" >> "$GITHUB_OUTPUT"
-          elif ! grep -q "\[${VERSION}\]" CHANGELOG.md; then
-            echo "No changelog entry for $VERSION, skipping"
-            echo "should_tag=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_tag=true" >> "$GITHUB_OUTPUT"
+          if [ -z "$CHANGED_PLUGINS" ]; then
+            echo "No plugin.json files changed, skipping"
+            exit 0
           fi
 
-      - name: Create tag
-        if: steps.check.outputs.should_tag == 'true'
-        run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          git tag "$TAG"
-          git push origin "$TAG"
-          echo "Created tag $TAG"
+          for plugin_json in $CHANGED_PLUGINS; do
+            # Extract plugin name from path: plugins/<name>/.claude-plugin/plugin.json
+            PLUGIN=$(echo "$plugin_json" | cut -d'/' -f2)
+            VERSION=$(python3 -c "import json; print(json.load(open('$plugin_json'))['version'])")
+            TAG="${PLUGIN}/v${VERSION}"
+
+            echo "Checking $PLUGIN v$VERSION..."
+
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "  Tag $TAG already exists, skipping"
+              continue
+            fi
+
+            if ! grep -q "\[${PLUGIN}/v${VERSION}\]" CHANGELOG.md; then
+              echo "  No changelog entry for $VERSION, skipping"
+              continue
+            fi
+
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "  Created tag $TAG"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,18 +84,18 @@ When asked to "cut a release" or "release a new version":
    - `minor` — new skills, agents, or significant behavior changes
    - `patch` — bug fixes, doc updates, minor improvements
 
-2. **Write the changelog entry** in `CHANGELOG.md` (repo root). Keep it scannable. Link each line to its PR with inline markdown links (e.g., `([#27](https://github.com/tmchow/tmc-marketplace/pull/27))`). Add a version comparison link reference at the bottom of the file (e.g., `[1.3.5]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.4...v1.3.5`). Make the version header a link using the reference (e.g., `## [1.3.5]`).
+2. **Write the changelog entry** in `CHANGELOG.md` (repo root). Keep it scannable. Use scoped version headers: `## [<plugin-name>/v<version>]`. Link each line to its PR with inline markdown links (e.g., `([#27](https://github.com/tmchow/tmc-marketplace/pull/27))`). Add a version comparison link reference at the bottom of the file (e.g., `[iterative-engineering/v1.3.5]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.4...iterative-engineering/v1.3.5`). Make the version header a link using the reference.
 
-3. **Run the release script** — bumps version in both `plugins/iterative-engineering/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (plugin entry only, not marketplace metadata):
+3. **Run the release script** — bumps version in both `plugins/<plugin-name>/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (plugin entry only, not marketplace metadata):
    ```bash
-   ./scripts/release.sh <major|minor|patch>
+   ./scripts/release.sh <plugin-name> <major|minor|patch>
    ```
 
 4. **Commit and open a PR:**
    ```bash
    git add -A && git commit -m "chore(release): <version>"
    ```
-   Push the branch and open a PR. The `v<version>` tag is created automatically when the PR merges (via `.github/workflows/auto-tag.yml`).
+   Push the branch and open a PR. A scoped tag (`<plugin-name>/v<version>`) is created automatically when the PR merges (via `.github/workflows/auto-tag.yml`).
 
 ## Commit and PR Conventions
 
@@ -185,14 +185,14 @@ This keeps orchestrator prompts lean (the rules live in the skill) and agent def
 ## Installation (for users)
 
 ```bash
-# Install both (default)
+# Interactive menu (default)
 curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
 
-# Codex skills only
-curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --codex-only
+# All plugins, no menu
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --all
 
-# Claude Code plugin only
-curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --claude-only
+# Single plugin
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --plugin image-sprout
 ```
 
 Or install manually:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.15.0] - 2026-03-05
+## [iterative-engineering/v1.15.0] - 2026-03-05
 
 ### Changed
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.14.0] - 2026-03-04
+## [iterative-engineering/v1.14.0] - 2026-03-04
 
 ### Changed
 
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.13.0] - 2026-03-03
+## [iterative-engineering/v1.13.0] - 2026-03-03
 
 ### Changed
 
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.12.0] - 2026-03-02
+## [iterative-engineering/v1.12.0] - 2026-03-02
 
 ### Added
 
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.11.0] - 2026-03-01
+## [iterative-engineering/v1.11.0] - 2026-03-01
 
 ### Added
 
@@ -76,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.10.0] - 2026-02-20
+## [iterative-engineering/v1.10.0] - 2026-02-20
 
 ### Added
 
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.9.2] - 2026-02-19
+## [iterative-engineering/v1.9.2] - 2026-02-19
 
 ### Fixed
 
@@ -103,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.9.1] - 2026-02-19
+## [iterative-engineering/v1.9.1] - 2026-02-19
 
 ### Changed
 
@@ -119,7 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.9.0] - 2026-02-19
+## [iterative-engineering/v1.9.0] - 2026-02-19
 
 ### Changed
 
@@ -140,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.8.0] - 2026-02-17
+## [iterative-engineering/v1.8.0] - 2026-02-17
 
 ### Added
 
@@ -156,7 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.5] - 2026-02-15
+## [iterative-engineering/v1.7.5] - 2026-02-15
 
 ### Fixed
 
@@ -164,7 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.4] - 2026-02-14
+## [iterative-engineering/v1.7.4] - 2026-02-14
 
 ### Changed
 
@@ -172,7 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.3] - 2026-02-13
+## [iterative-engineering/v1.7.3] - 2026-02-13
 
 ### Fixed
 
@@ -181,7 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.2] - 2026-02-13
+## [iterative-engineering/v1.7.2] - 2026-02-13
 
 ### Changed
 
@@ -189,7 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.1] - 2026-02-13
+## [iterative-engineering/v1.7.1] - 2026-02-13
 
 ### Fixed
 
@@ -198,7 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.0] - 2026-02-11
+## [iterative-engineering/v1.7.0] - 2026-02-11
 
 ### Added
 
@@ -210,7 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.6.0] - 2026-02-10
+## [iterative-engineering/v1.6.0] - 2026-02-10
 
 ### Added
 
@@ -229,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.5.0] - 2026-02-10
+## [iterative-engineering/v1.5.0] - 2026-02-10
 
 ### Changed
 
@@ -245,7 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.4.2] - 2026-02-10
+## [iterative-engineering/v1.4.2] - 2026-02-10
 
 ### Fixed
 
@@ -260,7 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.4.1] - 2026-02-10
+## [iterative-engineering/v1.4.1] - 2026-02-10
 
 ### Fixed
 
@@ -270,7 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.4.0] - 2026-02-09
+## [iterative-engineering/v1.4.0] - 2026-02-09
 
 ### Added
 
@@ -285,7 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.5] - 2026-02-09
+## [iterative-engineering/v1.3.5] - 2026-02-09
 
 ### Fixed
 
@@ -298,7 +298,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.4] - 2026-02-09
+## [iterative-engineering/v1.3.4] - 2026-02-09
 
 ### Fixed
 
@@ -309,7 +309,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.3] - 2026-02-09
+## [iterative-engineering/v1.3.3] - 2026-02-09
 
 ### Fixed
 
@@ -325,7 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.2] - 2026-02-08
+## [iterative-engineering/v1.3.2] - 2026-02-08
 
 ### Fixed
 
@@ -333,7 +333,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.1] - 2026-02-08
+## [iterative-engineering/v1.3.1] - 2026-02-08
 
 ### Changed
 
@@ -345,7 +345,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.0] - 2026-02-08
+## [iterative-engineering/v1.3.0] - 2026-02-08
 
 ### Added
 
@@ -354,7 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.0] - 2026-02-08
+## [iterative-engineering/v1.2.0] - 2026-02-08
 
 ### Added
 
@@ -371,7 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.1.0] - 2026-02-08
+## [iterative-engineering/v1.1.0] - 2026-02-08
 
 ### Added
 
@@ -379,40 +379,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.0] - 2026-02-08
+## [iterative-engineering/v1.0.0] - 2026-02-08
 
 Initial release — 11 skills, 13 agents. ([#10](https://github.com/tmchow/tmc-marketplace/pull/10))
 
 Core workflow: brainstorming → research → spike → tech planning → implementing, with multi-agent reviews at each stage.
 
 <!-- Version comparison links -->
-[1.15.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.14.0...v1.15.0
-[1.14.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.13.0...v1.14.0
-[1.13.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.12.0...v1.13.0
-[1.12.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.11.0...v1.12.0
-[1.11.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.10.0...v1.11.0
-[1.10.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.9.2...v1.10.0
-[1.9.2]: https://github.com/tmchow/tmc-marketplace/compare/v1.9.1...v1.9.2
-[1.9.1]: https://github.com/tmchow/tmc-marketplace/compare/v1.9.0...v1.9.1
-[1.9.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.8.0...v1.9.0
-[1.8.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.5...v1.8.0
-[1.7.5]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.4...v1.7.5
-[1.7.4]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.3...v1.7.4
-[1.7.3]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.2...v1.7.3
-[1.7.2]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.1...v1.7.2
-[1.7.1]: https://github.com/tmchow/tmc-marketplace/compare/v1.7.0...v1.7.1
-[1.7.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.6.0...v1.7.0
-[1.6.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.5.0...v1.6.0
-[1.5.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.4.2...v1.5.0
-[1.4.2]: https://github.com/tmchow/tmc-marketplace/compare/v1.4.1...v1.4.2
-[1.4.1]: https://github.com/tmchow/tmc-marketplace/compare/v1.4.0...v1.4.1
-[1.4.0]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.5...v1.4.0
-[1.3.5]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.4...v1.3.5
-[1.3.4]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.3...v1.3.4
-[1.3.3]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.2...v1.3.3
-[1.3.2]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/tmchow/tmc-marketplace/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/tmchow/tmc-marketplace/releases/tag/v1.3.0
-[1.2.0]: https://github.com/tmchow/tmc-marketplace/compare/438b3a4...e83aba2
-[1.1.0]: https://github.com/tmchow/tmc-marketplace/compare/cca60ff...438b3a4
-[1.0.0]: https://github.com/tmchow/tmc-marketplace/compare/88dcd58...cca60ff
+[iterative-engineering/v1.15.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.14.0...iterative-engineering/v1.15.0
+[iterative-engineering/v1.14.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.13.0...iterative-engineering/v1.14.0
+[iterative-engineering/v1.13.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.12.0...iterative-engineering/v1.13.0
+[iterative-engineering/v1.12.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.11.0...iterative-engineering/v1.12.0
+[iterative-engineering/v1.11.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.10.0...iterative-engineering/v1.11.0
+[iterative-engineering/v1.10.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.9.2...iterative-engineering/v1.10.0
+[iterative-engineering/v1.9.2]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.9.1...iterative-engineering/v1.9.2
+[iterative-engineering/v1.9.1]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.9.0...iterative-engineering/v1.9.1
+[iterative-engineering/v1.9.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.8.0...iterative-engineering/v1.9.0
+[iterative-engineering/v1.8.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.5...iterative-engineering/v1.8.0
+[iterative-engineering/v1.7.5]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.4...iterative-engineering/v1.7.5
+[iterative-engineering/v1.7.4]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.3...iterative-engineering/v1.7.4
+[iterative-engineering/v1.7.3]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.2...iterative-engineering/v1.7.3
+[iterative-engineering/v1.7.2]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.1...iterative-engineering/v1.7.2
+[iterative-engineering/v1.7.1]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.7.0...iterative-engineering/v1.7.1
+[iterative-engineering/v1.7.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.6.0...iterative-engineering/v1.7.0
+[iterative-engineering/v1.6.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.5.0...iterative-engineering/v1.6.0
+[iterative-engineering/v1.5.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.4.2...iterative-engineering/v1.5.0
+[iterative-engineering/v1.4.2]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.4.1...iterative-engineering/v1.4.2
+[iterative-engineering/v1.4.1]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.4.0...iterative-engineering/v1.4.1
+[iterative-engineering/v1.4.0]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.5...iterative-engineering/v1.4.0
+[iterative-engineering/v1.3.5]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.4...iterative-engineering/v1.3.5
+[iterative-engineering/v1.3.4]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.3...iterative-engineering/v1.3.4
+[iterative-engineering/v1.3.3]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.2...iterative-engineering/v1.3.3
+[iterative-engineering/v1.3.2]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.1...iterative-engineering/v1.3.2
+[iterative-engineering/v1.3.1]: https://github.com/tmchow/tmc-marketplace/compare/iterative-engineering/v1.3.0...iterative-engineering/v1.3.1
+[iterative-engineering/v1.3.0]: https://github.com/tmchow/tmc-marketplace/releases/tag/iterative-engineering/v1.3.0
+[iterative-engineering/v1.2.0]: https://github.com/tmchow/tmc-marketplace/compare/438b3a4...e83aba2
+[iterative-engineering/v1.1.0]: https://github.com/tmchow/tmc-marketplace/compare/cca60ff...438b3a4
+[iterative-engineering/v1.0.0]: https://github.com/tmchow/tmc-marketplace/compare/88dcd58...cca60ff

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ Plugins for Claude Code and Codex by Trevin Chow.
 curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
 ```
 
-Installs the Claude Code plugin and Codex skills. Safe to re-run (idempotent). Skips anything not detected (e.g., no Codex installed).
+Shows an interactive menu to choose which plugins to install. Safe to re-run (idempotent). Skips anything not detected (e.g., no Codex installed).
 
-Install only one target:
+Install without the menu:
+
+```bash
+# All plugins at once
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --all
+
+# Just one plugin
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --plugin image-sprout
+```
+
+Install only one target (Claude Code or Codex):
 
 ```bash
 # Codex skills only
@@ -20,6 +30,13 @@ curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/script
 
 # Claude Code plugin only
 curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --claude-only
+```
+
+Combine flags to narrow both axes:
+
+```bash
+# Single plugin, Claude Code only
+curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --plugin iterative-engineering --claude-only
 ```
 
 To uninstall:
@@ -35,6 +52,7 @@ curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/script
 ```
 /plugin marketplace add tmchow/tmc-marketplace
 /plugin install iterative-engineering@tmc-marketplace
+/plugin install image-sprout@tmc-marketplace
 ```
 
 Verify with `/plugin list`.
@@ -56,6 +74,7 @@ This extracts all skills (with their reference files) to `~/.codex/skills/`.
 | Plugin | Description |
 |--------|-------------|
 | [iterative-engineering](./plugins/iterative-engineering) | Iterative development workflow — brainstorming → tech planning → implementing with multi-agent reviews, dependency-aware execution, and severity-based acceptance |
+| [image-sprout](./plugins/image-sprout) | Generate and iterate on images with consistent style and subject identity using the [image-sprout](https://github.com/tmchow/image-sprout) CLI |
 
 ## Changelog
 

--- a/plugins/image-sprout/.claude-plugin/plugin.json
+++ b/plugins/image-sprout/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "image-sprout",
+  "version": "1.0.2",
+  "description": "Skill for generating and iterating on images with consistent style and subject identity using the image-sprout CLI.",
+  "author": {
+    "name": "Trevin Chow",
+    "url": "https://trev.in"
+  },
+  "repository": "https://github.com/tmchow/tmc-marketplace",
+  "license": "MIT",
+  "keywords": [
+    "image-generation",
+    "image-sprout",
+    "style-consistency",
+    "cli"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/image-sprout/README.md
+++ b/plugins/image-sprout/README.md
@@ -1,0 +1,25 @@
+# image-sprout
+
+Claude Code plugin for [image-sprout](https://github.com/tmchow/image-sprout) — generate and iterate on images with consistent style and subject identity.
+
+## What it does
+
+Provides a skill that teaches Claude how to use the image-sprout CLI to create projects, manage reference images, derive style/subject guides, and generate images with repeatable context.
+
+## Prerequisites
+
+- [image-sprout](https://github.com/tmchow/image-sprout) installed (`npm install -g image-sprout`) or available via `npx`
+- An [OpenRouter](https://openrouter.ai/) API key configured via `npx image-sprout config set apiKey <key>`
+
+## Install
+
+```
+/plugin marketplace add tmchow/tmc-marketplace
+/plugin install image-sprout@tmc-marketplace
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| image-sprout | Create and manage image generation projects with consistent style and subject identity |

--- a/plugins/image-sprout/skills/agents/SKILL.md
+++ b/plugins/image-sprout/skills/agents/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: image-sprout
+description: >
+  Use image-sprout to create and manage image generation projects with consistent
+  style and subject identity. Use this skill when the user asks to generate images
+  with saved context, iteratively refine image outputs, manage image projects with
+  references and guides, or run image-sprout CLI commands in a workflow.
+---
+
+# image-sprout
+
+Generate and iterate on images with consistent style and subject identity. Image Sprout turns reusable project context — reference images, derived guides, and persistent instructions — into repeatable outputs you can build on across runs.
+
+Use this skill when:
+- The user asks to generate images and wants results that stay consistent across multiple runs
+- The user wants to iterate on outputs from a previous generation
+- The user needs to set up or manage an image project with references or style context
+- The workflow requires structured, scriptable image generation with `--json` output
+
+## 1. Installation
+
+Install globally from npm:
+
+```bash
+npm install -g image-sprout
+```
+
+Or run without installing — prefer this in Codex sandbox environments where PATH is unreliable:
+
+```bash
+npx image-sprout help
+```
+
+All examples below use `npx image-sprout`. Substitute `image-sprout` directly if you have a global install.
+
+## 2. OpenRouter Key Setup
+
+Image Sprout stores its OpenRouter key on disk. Set it once per machine:
+
+```bash
+npx image-sprout config set apiKey <your-openrouter-key>
+npx image-sprout config show    # confirm key is set (does not reveal the raw key)
+```
+
+## 3. The Project Model
+
+Three context layers drive every generation:
+
+- **Visual Style** — consistent look and feel across outputs
+- **Subject Guide** — consistent subject identity across outputs
+- **Instructions** — persistent generation constraints (watermarks, framing, branding)
+
+Two reference pools:
+
+- **Shared refs** — drive both guides (default, simplest)
+- **Split refs** — separate style and subject pools (advanced; use `--role style` or `--role subject` when adding)
+
+Understanding this model prevents the most common agent mistake: generating without saved context and wondering why outputs are inconsistent.
+
+## 4. Core CLI Workflow
+
+```bash
+# Create a project
+npx image-sprout project create <name>
+
+# Add references (3+ recommended; more refs = better derivation)
+npx image-sprout ref add --project <name> ./ref1.png ./ref2.png ./ref3.png
+
+# Optional: persistent instructions
+npx image-sprout project update <name> --instructions "Watermark bottom-right: subtle."
+
+# Derive guides from refs
+npx image-sprout project derive <name> --target both   # or: style, subject
+
+# Check readiness before generating
+npx image-sprout project status <name> --json
+
+# Generate (--count controls images per run: 1, 2, 4, 6; default is 4)
+npx image-sprout project generate <name> --prompt "hero in neon rain"
+npx image-sprout project generate <name> --prompt "hero in neon rain" --count 1
+
+# Inspect results
+npx image-sprout run latest --project <name> --json
+
+# Delete a session and all its runs/images
+npx image-sprout session delete --project <name> <session-id>
+```
+
+Top-level aliases:
+
+```bash
+npx image-sprout generate --project <name> --prompt "hero in neon rain"   # same as project generate
+npx image-sprout analyze --project <name> --target both                    # same as project derive
+```
+
+## 5. JSON Output — the Agent Pattern
+
+Always use `--json` for structured output:
+
+```bash
+npx image-sprout project show <name> --json
+npx image-sprout project status <name> --json
+npx image-sprout run latest --project <name> --json
+npx image-sprout run list --project <name> --json --limit 5
+```
+
+Use `--value PATH` to pluck a single field:
+
+```bash
+npx image-sprout run latest --project <name> --json --value images[0].path
+```
+
+This is how agents hand image paths to downstream tools. Run images land in image-sprout's internal app data directory — use `run latest --json --value images[0].path` to get the path and leave what to do with it to the calling workflow.
+
+## 6. Parallel-Safe Usage
+
+`npx image-sprout project use <name>` sets a shared "current project" state on disk. In multi-agent workflows, this state can collide across concurrent processes. **Always pass `--project <name>` explicitly** — never rely on the current project shortcut.
+
+## 7. Web UI — Agent Awareness
+
+The web app runs over the same on-disk store as the CLI. Agents won't use it directly, but should surface it to users when interactive review is appropriate.
+
+```bash
+npx image-sprout web              # launches local app
+npx image-sprout web --open       # also opens in default browser
+npx image-sprout web --port 8080  # custom port (default: 4310)
+```
+
+Useful for:
+- reviewing and comparing generated images visually
+- setting up a project interactively before handing off to CLI/agent use
+- iterating on outputs via the canvas interface
+
+**Security: do not expose the web UI to the public internet.** The server has no authentication. Safe options are localhost only, or a private network like Tailscale. The risk is public internet exposure — LAN and tailnet access are fine.
+
+## 8. Model Management
+
+```bash
+npx image-sprout model list
+npx image-sprout model set-default google/gemini-3.1-flash-image-preview
+npx image-sprout model add openai/gpt-5-image
+npx image-sprout model restore-defaults
+```
+
+Default generation model is **Nano Banana 2** (`google/gemini-3.1-flash-image-preview`). Custom models must accept image input and produce image output via OpenRouter.
+
+Guide derivation uses a separate configurable analysis model (default: `google/gemini-3.1-flash-image-preview`):
+
+```bash
+# Set a persistent analysis model
+npx image-sprout config set analysisModel google/gemini-2.5-flash
+
+# Override per-derive
+npx image-sprout project derive <name> --target both --analysis-model google/gemini-2.5-flash
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,20 +3,24 @@ set -euo pipefail
 
 # TMC Marketplace Installer
 # Usage:
-#   Install:   curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
-#   Codex only:  curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --codex-only
-#   Claude only: curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --claude-only
-#   Uninstall: curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --uninstall
+#   Interactive:     curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash
+#   All plugins:     curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --all
+#   Single plugin:   curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --plugin image-sprout
+#   Codex only:      curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --codex-only
+#   Claude only:     curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --claude-only
+#   Uninstall:       curl -fsSL "https://raw.githubusercontent.com/tmchow/tmc-marketplace/main/scripts/install.sh?$(date +%s)" | bash -s -- --uninstall
 
 # --- Constants ---
-VERSION="1.0.0"
+VERSION="2.0.0"
 REPO="tmchow/tmc-marketplace"
-PLUGIN_NAME="iterative-engineering"
 MARKETPLACE_NAME="tmc-marketplace"
 ARCHIVE_URL="https://github.com/${REPO}/archive/refs/heads/main.tar.gz"
 ARCHIVE_PREFIX="tmc-marketplace-main"
 MAX_RETRIES=3
 RETRY_DELAY=2
+
+# All available plugins in the marketplace
+ALL_PLUGINS=("iterative-engineering" "image-sprout")
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -31,6 +35,8 @@ UNINSTALL=false
 INSTALL_CLAUDE=true
 INSTALL_CODEX=true
 INSTALL_TARGET="both"
+INSTALL_ALL=false
+SELECTED_PLUGINS=()
 LAST_DOWNLOAD_ERROR=""
 
 # --- Utility functions ---
@@ -85,6 +91,49 @@ download_with_retry() {
     return 1
 }
 
+# --- Plugin selection ---
+
+prompt_plugin_selection() {
+    # When piped via curl | bash, stdin is the pipe. Read from /dev/tty for user input.
+    if ! [ -t 0 ] && ! [ -e /dev/tty ]; then
+        log_warn "No interactive terminal available, installing all plugins"
+        SELECTED_PLUGINS=("${ALL_PLUGINS[@]}")
+        return
+    fi
+
+    echo "" >&2
+    echo -e "${BOLD}Available plugins:${NC}" >&2
+    echo "" >&2
+
+    local i=1
+    for plugin in "${ALL_PLUGINS[@]}"; do
+        echo -e "  ${BOLD}${i})${NC} ${plugin}" >&2
+        ((i++))
+    done
+
+    echo "" >&2
+    echo -e "Enter plugin numbers separated by spaces (e.g. ${BOLD}1 2${NC}), or ${BOLD}a${NC} for all:" >&2
+    read -r selection < /dev/tty
+
+    if [[ "$selection" == "a" || "$selection" == "A" || -z "$selection" ]]; then
+        SELECTED_PLUGINS=("${ALL_PLUGINS[@]}")
+        return
+    fi
+
+    SELECTED_PLUGINS=()
+    for num in $selection; do
+        if [[ "$num" =~ ^[0-9]+$ ]] && [ "$num" -ge 1 ] && [ "$num" -le ${#ALL_PLUGINS[@]} ]; then
+            SELECTED_PLUGINS+=("${ALL_PLUGINS[$((num - 1))]}")
+        else
+            die "Invalid selection: $num"
+        fi
+    done
+
+    if [ ${#SELECTED_PLUGINS[@]} -eq 0 ]; then
+        die "No plugins selected"
+    fi
+}
+
 # --- Core functions ---
 
 print_banner() {
@@ -96,7 +145,8 @@ print_banner() {
 }
 
 install_claude_plugin() {
-    log_info "Installing Claude Code plugin..."
+    local plugin_name="$1"
+    log_info "Installing Claude Code plugin: ${plugin_name}..."
 
     if ! command -v claude &>/dev/null; then
         log_warn "Claude Code CLI not found, skipping plugin install"
@@ -107,23 +157,44 @@ install_claude_plugin() {
     # Add marketplace (idempotent; may return non-zero if already added)
     local marketplace_output
     if ! marketplace_output=$(claude plugin marketplace add "${REPO}" 2>&1); then
-        log_warn "Failed to add marketplace (may already exist), continuing"
-        print_details "$marketplace_output"
+        # Ignore — marketplace may already exist
+        true
     fi
 
     # Install plugin (idempotent - reinstalls/updates if exists)
     local install_output
-    if ! install_output=$(claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}" 2>&1); then
-        log_warn "Failed to install plugin"
+    if ! install_output=$(claude plugin install "${plugin_name}@${MARKETPLACE_NAME}" 2>&1); then
+        log_warn "Failed to install ${plugin_name}"
         print_details "$install_output"
         return 0
     fi
 
-    log_success "Installed ${PLUGIN_NAME}@${MARKETPLACE_NAME} plugin"
+    log_success "Installed ${plugin_name}@${MARKETPLACE_NAME} plugin"
+}
+
+download_and_extract_archive() {
+    CODEX_EXTRACT_DIR=$(mktemp -d)
+    local archive_path="${CODEX_EXTRACT_DIR}/archive.tar.gz"
+
+    if ! download_with_retry "$ARCHIVE_URL" "$archive_path"; then
+        rm -rf "$CODEX_EXTRACT_DIR"
+        CODEX_EXTRACT_DIR=""
+        log_warn "Failed to download archive after $MAX_RETRIES attempts"
+        if [ -n "$LAST_DOWNLOAD_ERROR" ]; then
+            print_details "$LAST_DOWNLOAD_ERROR"
+        fi
+        return 1
+    fi
+
+    tar xzf "$archive_path" -C "$CODEX_EXTRACT_DIR"
+    rm -f "$archive_path"
+    return 0
 }
 
 install_codex_skills() {
-    log_info "Installing Codex skills..."
+    local plugin_name="$1"
+    local extract_dir="$2"
+    log_info "Installing Codex skills for ${plugin_name}..."
 
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
 
@@ -139,34 +210,15 @@ install_codex_skills() {
 
     local skills_dir="${codex_home}/skills"
     mkdir -p "$skills_dir"
-    local tmp_dir
-    tmp_dir=$(mktemp -d)
 
-    # Download archive
-    local archive_path="${tmp_dir}/archive.tar.gz"
-    if ! download_with_retry "$ARCHIVE_URL" "$archive_path"; then
-        rm -rf "$tmp_dir"
-        log_warn "Failed to download skills after $MAX_RETRIES attempts"
-        if [ -n "$LAST_DOWNLOAD_ERROR" ]; then
-            print_details "$LAST_DOWNLOAD_ERROR"
-        fi
-        return 0
-    fi
-
-    # Extract
-    local extract_dir="${tmp_dir}/extracted"
-    mkdir -p "$extract_dir"
-    tar xzf "$archive_path" -C "$extract_dir"
-
-    local source_skills="${extract_dir}/${ARCHIVE_PREFIX}/plugins/${PLUGIN_NAME}/skills"
+    local source_skills="${extract_dir}/${ARCHIVE_PREFIX}/plugins/${plugin_name}/skills"
     if [ ! -d "$source_skills" ]; then
-        rm -rf "$tmp_dir"
-        log_warn "Skills directory not found in archive"
+        log_warn "Skills directory not found in archive for ${plugin_name}"
         return 0
     fi
 
     # Copy each skill and record in manifest
-    local manifest="${skills_dir}/.tmc-marketplace"
+    local manifest="${skills_dir}/.tmc-marketplace-${plugin_name}"
     local count=0
     local installed_skills=()
 
@@ -183,10 +235,11 @@ install_codex_skills() {
     done
 
     # Write manifest for clean uninstall
-    printf '%s\n' "${installed_skills[@]}" > "$manifest"
+    if [ ${#installed_skills[@]} -gt 0 ]; then
+        printf '%s\n' "${installed_skills[@]}" > "$manifest"
+    fi
 
-    rm -rf "$tmp_dir"
-    log_success "Installed ${count} skills to ${skills_dir}/"
+    log_success "Installed ${count} skills for ${plugin_name} to ${skills_dir}/"
 }
 
 print_success() {
@@ -201,17 +254,19 @@ do_uninstall() {
     log_info "Uninstalling TMC Marketplace..."
     echo ""
 
-    # Remove Claude Code plugin
+    # Remove Claude Code plugins
     if command -v claude &>/dev/null; then
-        log_info "Removing Claude Code plugin..."
+        for plugin_name in "${ALL_PLUGINS[@]}"; do
+            log_info "Removing Claude Code plugin: ${plugin_name}..."
 
-        local uninstall_output
-        if uninstall_output=$(claude plugin uninstall "${PLUGIN_NAME}@${MARKETPLACE_NAME}" 2>&1); then
-            log_success "Removed Claude Code plugin"
-        else
-            log_warn "Claude Code plugin not found or failed to remove"
-            print_details "$uninstall_output"
-        fi
+            local uninstall_output
+            if uninstall_output=$(claude plugin uninstall "${plugin_name}@${MARKETPLACE_NAME}" 2>&1); then
+                log_success "Removed ${plugin_name}"
+            else
+                log_warn "${plugin_name} not found or failed to remove"
+                print_details "$uninstall_output"
+            fi
+        done
 
         local remove_output
         if remove_output=$(claude plugin marketplace remove "${REPO}" 2>&1); then
@@ -225,24 +280,35 @@ do_uninstall() {
     # Remove Codex skills
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
     local skills_dir="${codex_home}/skills"
-    local manifest="${skills_dir}/.tmc-marketplace"
 
-    if [ -f "$manifest" ]; then
-        log_info "Removing Codex skills..."
-        local removed=0
+    for plugin_name in "${ALL_PLUGINS[@]}"; do
+        local manifest="${skills_dir}/.tmc-marketplace-${plugin_name}"
+        # Also check legacy manifest name
+        if [[ "$plugin_name" == "iterative-engineering" ]] && [ ! -f "$manifest" ]; then
+            manifest="${skills_dir}/.tmc-marketplace"
+        fi
 
-        while IFS= read -r skill_name; do
-            [ -z "$skill_name" ] && continue
-            local skill_dir="${skills_dir}/${skill_name}"
-            if [ -d "$skill_dir" ]; then
-                rm -rf "$skill_dir"
-                ((removed++))
-            fi
-        done < "$manifest"
+        if [ -f "$manifest" ]; then
+            log_info "Removing Codex skills for ${plugin_name}..."
+            local removed=0
 
-        rm -f "$manifest"
-        log_success "Removed ${removed} Codex skills"
-    fi
+            while IFS= read -r skill_name; do
+                [ -z "$skill_name" ] && continue
+                local skill_dir="${skills_dir}/${skill_name}"
+                if [ -d "$skill_dir" ]; then
+                    rm -rf "$skill_dir"
+                    ((removed++))
+                fi
+            done < "$manifest"
+
+            rm -f "$manifest"
+            log_success "Removed ${removed} Codex skills for ${plugin_name}"
+        fi
+    done
+
+    # Clean up legacy manifest if it exists
+    local legacy_manifest="${skills_dir}/.tmc-marketplace"
+    [ -f "$legacy_manifest" ] && rm -f "$legacy_manifest"
 
     echo ""
 }
@@ -255,6 +321,27 @@ parse_args() {
             --uninstall)
                 UNINSTALL=true
                 shift
+                ;;
+            --all)
+                INSTALL_ALL=true
+                shift
+                ;;
+            --plugin)
+                if [[ $# -lt 2 ]]; then
+                    die "--plugin requires a plugin name"
+                fi
+                local valid=false
+                for p in "${ALL_PLUGINS[@]}"; do
+                    if [[ "$p" == "$2" ]]; then
+                        valid=true
+                        break
+                    fi
+                done
+                if [[ "$valid" != "true" ]]; then
+                    die "Unknown plugin: $2. Available: ${ALL_PLUGINS[*]}"
+                fi
+                SELECTED_PLUGINS+=("$2")
+                shift 2
                 ;;
             --claude-only)
                 if [[ "$INSTALL_TARGET" == "codex" ]]; then
@@ -274,16 +361,22 @@ parse_args() {
                 echo "TMC Marketplace Installer v${VERSION}"
                 echo ""
                 echo "Usage:"
-                echo "  Install:   curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash"
-                echo "  Codex:     curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --codex-only"
-                echo "  Claude:    curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --claude-only"
-                echo "  Uninstall: curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --uninstall"
+                echo "  Install:       curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash"
+                echo "  Install all:   curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --all"
+                echo "  One plugin:    curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --plugin <name>"
+                echo "  Codex:         curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --codex-only"
+                echo "  Claude:        curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --claude-only"
+                echo "  Uninstall:     curl -fsSL \"https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh?\$(date +%s)\" | bash -s -- --uninstall"
                 echo ""
                 echo "Options:"
-                echo "  --uninstall    Remove plugin and skills"
+                echo "  --all          Install all plugins (non-interactive)"
+                echo "  --plugin NAME  Install a specific plugin (repeatable)"
+                echo "  --uninstall    Remove all plugins and skills"
                 echo "  --codex-only   Install Codex skills only"
                 echo "  --claude-only  Install Claude Code plugin only"
                 echo "  --help, -h     Show this help message"
+                echo ""
+                echo "Available plugins: ${ALL_PLUGINS[*]}"
                 exit 0
                 ;;
             *)
@@ -320,15 +413,44 @@ main() {
 
     if [[ "$UNINSTALL" == "true" ]]; then
         do_uninstall
-    else
+        return
+    fi
+
+    # Determine which plugins to install
+    if [[ "$INSTALL_ALL" == "true" ]]; then
+        SELECTED_PLUGINS=("${ALL_PLUGINS[@]}")
+    elif [ ${#SELECTED_PLUGINS[@]} -eq 0 ]; then
+        # Default: interactive selection
+        prompt_plugin_selection
+    fi
+
+    log_info "Installing plugins: ${SELECTED_PLUGINS[*]}"
+    echo ""
+
+    # Download archive once if Codex install is needed
+    CODEX_EXTRACT_DIR=""
+    if [[ "$INSTALL_CODEX" == "true" ]]; then
+        if ! download_and_extract_archive; then
+            INSTALL_CODEX=false
+        fi
+    fi
+
+    for plugin_name in "${SELECTED_PLUGINS[@]}"; do
         if [[ "$INSTALL_CLAUDE" == "true" ]]; then
-            install_claude_plugin
+            install_claude_plugin "$plugin_name"
         fi
         if [[ "$INSTALL_CODEX" == "true" ]]; then
-            install_codex_skills
+            install_codex_skills "$plugin_name" "$CODEX_EXTRACT_DIR"
         fi
-        print_success
+        echo ""
+    done
+
+    # Clean up extracted archive
+    if [ -n "$CODEX_EXTRACT_DIR" ] && [ -d "$CODEX_EXTRACT_DIR" ]; then
+        rm -rf "$CODEX_EXTRACT_DIR"
     fi
+
+    print_success
 }
 
 main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./scripts/release.sh <major|minor|patch>
+# Usage: ./scripts/release.sh <plugin-name> <major|minor|patch>
 # Bumps plugin version in plugin.json and marketplace.json plugin entry.
 # Changelog entry should be written before running this script.
 
-BUMP_TYPE="${1:-}"
-PLUGIN="iterative-engineering"
+PLUGIN="${1:-}"
+BUMP_TYPE="${2:-}"
+
+if [[ -z "$PLUGIN" ]] || [[ -z "$BUMP_TYPE" ]] || [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
+  echo "Usage: ./scripts/release.sh <plugin-name> <major|minor|patch>"
+  echo ""
+  echo "Available plugins:"
+  for dir in plugins/*/; do
+    [ -d "$dir" ] && echo "  $(basename "$dir")"
+  done
+  exit 1
+fi
+
 PLUGIN_JSON="plugins/$PLUGIN/.claude-plugin/plugin.json"
 MARKETPLACE_JSON=".claude-plugin/marketplace.json"
 
-if [[ -z "$BUMP_TYPE" ]] || [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
-  echo "Usage: ./scripts/release.sh <major|minor|patch>"
+if [[ ! -f "$PLUGIN_JSON" ]]; then
+  echo "Error: Plugin not found: $PLUGIN (no $PLUGIN_JSON)"
   exit 1
 fi
 
@@ -34,7 +45,7 @@ esac
 
 NEW_VERSION="$MAJOR.$MINOR.$PATCH"
 
-echo "Bumping $CURRENT_VERSION → $NEW_VERSION ($BUMP_TYPE)"
+echo "[$PLUGIN] Bumping $CURRENT_VERSION → $NEW_VERSION ($BUMP_TYPE)"
 
 # Update plugin.json
 python3 -c "
@@ -68,4 +79,4 @@ echo "  1. Verify CHANGELOG.md has an entry for $NEW_VERSION"
 echo "  2. Commit: git add -A && git commit -m 'chore(release): $NEW_VERSION'"
 echo "  3. Push and open a PR"
 echo ""
-echo "Tag v$NEW_VERSION is created automatically when the PR merges."
+echo "Tag $PLUGIN/v$NEW_VERSION is created automatically when the PR merges."


### PR DESCRIPTION
## Summary

- Adds **image-sprout** plugin (v1.0.2) with a skill for consistent image generation via the [image-sprout](https://github.com/tmchow/image-sprout) CLI
- Overhauls **install.sh** (v2.0.0) to support multiple plugins: interactive selection menu (default), `--all`, `--plugin <name>`, single archive download for Codex installs, `/dev/tty` support for `curl | bash`
- Updates **release.sh** to take `<plugin-name> <major|minor|patch>` instead of just bump type
- Updates **auto-tag workflow** to detect which `plugin.json` files changed and create scoped tags (`iterative-engineering/v1.15.0`, `image-sprout/v1.0.2`)
- Migrates all **changelog entries** to scoped format (`iterative-engineering/v*`) with updated comparison links
- Updates **README** and **AGENTS.md** with new plugin listing and install docs

## Test plan

- [ ] Run `bash scripts/install.sh --help` to verify new help text
- [ ] Run `bash -n scripts/install.sh && bash -n scripts/release.sh` to verify syntax
- [ ] Run `./scripts/release.sh` with no args to verify usage message lists both plugins
- [ ] Run `./scripts/release.sh image-sprout patch` to verify it bumps correctly (then reset)
- [ ] Verify changelog links render correctly on GitHub
- [ ] Test interactive menu locally: `bash scripts/install.sh` (should prompt for selection)
- [ ] Test `bash scripts/install.sh --plugin image-sprout --claude-only`