### PR TITLE
fix: avoid set-e abort in installer counters

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -231,7 +231,7 @@ install_codex_skills() {
         rm -rf "$dest"
         cp -r "$skill_dir" "$dest"
         installed_skills+=("$skill_name")
-        ((count++))
+        count=$((count + 1))
     done
 
     # Write manifest for clean uninstall
@@ -297,7 +297,7 @@ do_uninstall() {
                 local skill_dir="${skills_dir}/${skill_name}"
                 if [ -d "$skill_dir" ]; then
                     rm -rf "$skill_dir"
-                    ((removed++))
+                    removed=$((removed + 1))
                 fi
             done < "$manifest"
 


### PR DESCRIPTION
## Summary
- replace post-increment arithmetic in the installer copy loop so set -e does not abort after the first skill
- replace the same pattern in uninstall cleanup so removal counts do not trigger the same shell behavior

## Verification
- bash -n scripts/install.sh
- bash -lc 'set -e; count=0; count=1; echo survived-count:; removed=0; removed=1; echo survived-removed:'

## Problem
Running the installer with --codex-only could copy the first skill and then exit early because ((count++)) returns status 1 on the first iteration under set -e.
