### PR TITLE
fix: trim design-exploration skill description to fit 1024 char limit

### DIFF
--- a/plugins/iterative-engineering/skills/design-exploration/SKILL.md
+++ b/plugins/iterative-engineering/skills/design-exploration/SKILL.md
@@ -2,21 +2,17 @@
 name: iterative:design-exploration
 description: >
   Explore radically different design approaches for any page, component, or feature.
-  This skill should be used whenever the user wants to compare multiple distinct visual
-  directions side by side — not build one specific thing, but see several fundamentally
-  different takes on the same UI. Common signals: "explore designs for", "show me
-  different ways to design", "I want to see radically different approaches", "what could
-  this look like", "design exploration", "let's see some options before we commit",
-  "different layout approaches", "different visual identities for the same content",
-  wanting to see multiple families or variations of a page/component before choosing a
-  direction. Also triggers when the user pastes design exploration feedback (starts with
-  "## Design Exploration Feedback") to iterate on a previous round, when they paste a
-  design direction (starts with "## Design Direction") to finalize, or when they
-  reference a previous design exploration gallery and want to refine it. Do NOT trigger
-  when the user wants to build one specific design (even if it's a UI component), do a
-  visual refresh of existing code, review or critique an existing design, brainstorm
-  requirements/features without visual output, prototype a single widget, or compare
-  CSS frameworks/tools.
+  Use when the user wants to compare multiple distinct visual directions side by side —
+  not build one specific thing, but see several fundamentally different takes on the
+  same UI. Signals: "explore designs for", "show me different ways to design",
+  "radically different approaches", "what could this look like", "design exploration",
+  "let's see some options before we commit", "different layout approaches", "different
+  visual identities for the same content", wanting to see multiple families or variations
+  before choosing a direction. Also triggers when the user pastes design exploration
+  feedback (starts with "## Design Exploration Feedback") to iterate on a previous round,
+  or pastes a design direction ("## Design Direction") to finalize. Do NOT trigger for
+  building one specific design, visual refreshes, design critiques, brainstorming without
+  visual output, single widget prototypes, or comparing CSS frameworks.
 ---
 
 # Design Exploration


### PR DESCRIPTION
## Summary
- The `design-exploration` skill description exceeded the 1024 character maximum (~1330 chars)
- Trimmed to 1001 characters while preserving all key trigger signals, feedback/direction block handling, and negative triggers
- Minimal removals: redundant phrasing ("starts with", "of existing code", "/tools")

## Test plan
- [ ] Verify skill installs without validation error
- [ ] Confirm skill still triggers correctly on design exploration requests